### PR TITLE
Feature: Check for dummy values

### DIFF
--- a/check_008_datum.py
+++ b/check_008_datum.py
@@ -1,0 +1,28 @@
+import xml.etree.ElementTree as ET
+
+def calculate_008_date_percentage(xml_file_path):
+    total_records = 0
+    matching_records = 0
+
+    # Iteriere über die Datei und lausche auf das 'end'-Ereignis
+    for event, elem in ET.iterparse(xml_file_path, events=('end',)):
+        if elem.tag == 'record':
+            total_records += 1  # Gesamtanzahl der Records hochzählen
+            controlfield_008 = elem.find('./controlfield[@tag="008"]')
+            if controlfield_008 is not None and controlfield_008.text.startswith("991231"):
+                matching_records += 1  # Anzahl der passenden Records hochzählen
+            
+            # Speicher freigeben für das verarbeitete Element
+            elem.clear()
+
+    if total_records > 0:
+        percentage = (matching_records / total_records) * 100
+    else:
+        percentage = 0
+
+    return percentage
+
+# Verwende die Funktion mit der XML-Datei
+xml_file_path = 'voebvoll-20241027.xml'
+percentage = calculate_008_date_percentage(xml_file_path)
+print(f"Percentage of records with controlfield tag='008' starting '991231': {percentage:.2f}%")

--- a/check_008_datum.py
+++ b/check_008_datum.py
@@ -9,7 +9,7 @@ def calculate_008_date_percentage(xml_file_path):
         if elem.tag == 'record':
             total_records += 1  # Gesamtanzahl der Records hochzählen
             controlfield_008 = elem.find('./controlfield[@tag="008"]')
-            if controlfield_008 is not None and controlfield_008.text.startswith("991231"):
+            if controlfield_008 is not None and controlfield_008.text is not None and controlfield_008.text.startswith("991231"):
                 matching_records += 1  # Anzahl der passenden Records hochzählen
             
             # Speicher freigeben für das verarbeitete Element

--- a/check_leader_element.py
+++ b/check_leader_element.py
@@ -1,0 +1,28 @@
+import xml.etree.ElementTree as ET
+
+def calculate_leader_01234cam_percentage(xml_file_path):
+    total_records = 0
+    matching_records = 0
+
+    # Iteriere über die XML-Datei, und lausche auf das 'end'-Ereignis, wenn jedes Element fertig geparst wurde.
+    for event, elem in ET.iterparse(xml_file_path, events=('end',)):
+        if elem.tag == 'record':
+            total_records += 1
+            leader = elem.find('leader')
+            if leader is not None and leader.text.startswith("01234cam"):
+                matching_records += 1
+            
+            # Speicher freigeben für das verarbeitete Element
+            elem.clear()
+
+    if total_records > 0:
+        percentage = (matching_records / total_records) * 100
+    else:
+        percentage = 0
+
+    return percentage
+
+# Verwende die Funktion mit der angegebenen XML-Datei
+xml_file_path = 'voebvoll-20241027.xml'
+percentage = calculate_leader_01234cam_percentage(xml_file_path)
+print(f"Percentage of records with leader starting '01234cam': {percentage:.2f}%")

--- a/check_leader_element.py
+++ b/check_leader_element.py
@@ -9,7 +9,7 @@ def calculate_leader_01234cam_percentage(xml_file_path):
         if elem.tag == 'record':
             total_records += 1
             leader = elem.find('leader')
-            if leader is not None and leader.text.startswith("01234cam"):
+            if leader is not None and leader.text is not None and leader.text.startswith("01234cam"):
                 matching_records += 1
             
             # Speicher freigeben für das verarbeitete Element

--- a/start.py
+++ b/start.py
@@ -57,8 +57,10 @@ def main() -> None:
         ("Nach Quelle splitten", "datensaetze_nach_quelle.py"),
         ("Metadatenelemente auflisten", "show_elements.py"),
         ("Metadatenelemente (Menge) analysieren", "show_elements_quantity.py"),
-        ("Prim\u00e4rschl\u00fcssel pr\u00fcfen", "check_primary_key_unique.py"),
-        ("ISBN pr\u00fcfen", "check_isbn.py"),
+        ("Primärschlüssel prüfen", "check_primary_key_unique.py"),
+        ("ISBN prüfen", "check_isbn.py"),
+        ("Leader prüfen", "check_leader_element.py"),
+        ("Datum prüfen", "check_008_datum.py"),
     ]
 
     for label, script in buttons:


### PR DESCRIPTION
This pull request introduces two new Python scripts to analyze XML files for specific patterns in MARC records. The scripts calculate percentages of records matching predefined criteria based on `controlfield` and `leader` elements. These changes enhance the ability to extract statistical insights from MARC XML datasets.

### New functionality for XML record analysis:

* [`check_008_datum.py`](diffhunk://#diff-8738b6825e819f1308051c096dfbda637a7635c53ad8a82ed617bca7ff180f7eR1-R28): Added a script to calculate the percentage of records where the `controlfield` with `tag="008"` starts with "991231". The script uses `xml.etree.ElementTree.iterparse` for efficient parsing and memory management.

* [`check_leader_element.py`](diffhunk://#diff-1eff3f619c82beaf424492b5fb25b977e455597b7452036456d96b3906eb30c0R1-R28): Added a script to calculate the percentage of records where the `leader` element starts with "01234cam". Similar to the previous script, it uses `xml.etree.ElementTree.iterparse` for efficient processing.